### PR TITLE
Improve the C# benchmark

### DIFF
--- a/dnx/Program.cs
+++ b/dnx/Program.cs
@@ -25,7 +25,7 @@ namespace ActorBenchmark
             var x2 = skynet(0, limit, 10, true);
             x2.Wait();
             sw.Stop();
-            
+
             Console.WriteLine(x2.Result);
             Console.WriteLine("Async sec: {0:0.000}", sw.ElapsedMilliseconds / 1000.0f);
         }
@@ -35,7 +35,7 @@ namespace ActorBenchmark
         {
             if (size == 1)
             {
-                return Task.FromResult(num);
+                return Task.Run(() => num);
             }
             else
             {

--- a/dnx/Program.cs
+++ b/dnx/Program.cs
@@ -10,19 +10,24 @@ namespace ActorBenchmark
     {
         static void Main(string[] args)
         {
+            Stopwatch sw = new Stopwatch();
             long limit = 1000000;
-            DateTime dt = DateTime.Now;
+
+            sw.Start();
             var x = skynet(0, limit, 10, false);
             x.Wait();
+            sw.Stop();
+
             Console.WriteLine(x.Result);
-            DateTime dt2 = DateTime.Now;
-            Console.WriteLine("Sync sec: {0:0.000}", (dt2 - dt).TotalSeconds);
+            Console.WriteLine("Sync sec: {0:0.000}", sw.ElapsedMilliseconds / 1000.0f);
+
+            sw.Restart();
             var x2 = skynet(0, limit, 10, true);
             x2.Wait();
-            DateTime dt3 = DateTime.Now;
+            sw.Stop();
+            
             Console.WriteLine(x2.Result);
-            Console.WriteLine("Async sec: {0:0.000}", (dt3 - dt2).TotalSeconds);
-            //Console.ReadLine();
+            Console.WriteLine("Async sec: {0:0.000}", sw.ElapsedMilliseconds / 1000.0f);
         }
         static object taskLock = new object();
 


### PR DESCRIPTION
This PR changes the C# benchmark to actually create tasks that have to be run, instead of just results. This makes the C# benchmark a bit slower, but more accurate and fair.

Additionally, `DateTime` isn't very accurate for measuring small time intervals, especially on Windows. This PR uses `System.Diagnostics.Stopwatch`, which is far more suitable for this task.
