### PR TITLE
gofmt and other idiomatic fixes

### DIFF
--- a/go/skynet.go
+++ b/go/skynet.go
@@ -4,27 +4,28 @@ import "fmt"
 import "time"
 
 func skynet(c chan int, num int, size int, div int) {
-    if (size == 1) {
-        c <- num
-    } else {
-        rc := make(chan int)
-        sum := 0
-        for i := 0; i < div; i++ {
-            sub_num := num + i * (size / div)
-            go skynet(rc, sub_num, size / div, div)
-        }
-        for i := 0; i < div; i++ {
-            sum += <-rc
-        }
-        c <- sum
-    }
+	if size == 1 {
+		c <- num
+		return
+	}
+
+	rc := make(chan int)
+	var sum int
+	for i := 0; i < div; i++ {
+		subNum := num + i*(size/div)
+		go skynet(rc, subNum, size/div, div)
+	}
+	for i := 0; i < div; i++ {
+		sum += <-rc
+	}
+	c <- sum
 }
 
 func main() {
-    c := make(chan int)
-    start := time.Now().UnixNano() / 1000000 
-    go skynet(c, 0, 1000000, 10)
-    result := <-c
-    end := time.Now().UnixNano() / 1000000
-    fmt.Printf("Result: %d in %d ms.\n", result, end - start)
+	c := make(chan int)
+	start := time.Now()
+	go skynet(c, 0, 1000000, 10)
+	result := <-c
+	took := time.Since(start)
+	fmt.Printf("Result: %d in %d ms.\n", result, took.Nanoseconds()/1e6)
 }


### PR DESCRIPTION
Just make it nicer Go code. Makes it a little bit faster, too, though it's likely just statistical noise.

```
$ go get github.com/peterbourgon/stats

$ cd $GOPATH/src/github.com/atemerev/skynet/go
$ go build 
$ for i in (seq 1 100) ; echo -n '.' ; ./go | awk '{print $4}' >> ~/orig.txt ; end ; echo
....................................................................................................
$ cat ~/orig.txt | stats
min 651.0000
max 1142.0000
sum 86212.0000
mean 862.1200
median 862.1200
modes [716 874 893 920 946 1008]
stdev 108.6932

$ cd $GOPATH/src/github.com/peterbourgon/skynet/go
$ go build
$ for i in (seq 1 100) ; echo -n '.' ; ./go | awk '{print $4}' >> ~/fork.txt ; end ; echo
....................................................................................................
$ cat ~/fork.txt | stats
min 649.0000
max 1110.0000
sum 83548.0000
mean 835.4800
median 835.4800
modes [768 999]
stdev 99.1190
```
