### PR TITLE
explicitly using int64 so it works consistently

### DIFF
--- a/go/skynet.go
+++ b/go/skynet.go
@@ -3,12 +3,12 @@ package main
 import "fmt"
 import "time"
 
-func skynet(c chan int, num int, size int, div int) {
+func skynet(c chan int64, num int, size int, div int) {
     if (size == 1) {
-        c <- num
+        c <- int64(num)
     } else {
-        rc := make(chan int)
-        sum := 0
+        rc := make(chan int64)
+        sum := int64(0)
         for i := 0; i < div; i++ {
             sub_num := num + i * (size / div)
             go skynet(rc, sub_num, size / div, div)
@@ -21,10 +21,11 @@ func skynet(c chan int, num int, size int, div int) {
 }
 
 func main() {
-    c := make(chan int)
-    start := time.Now().UnixNano() / 1000000 
+    c := make(chan int64)
+    start := time.Now().UnixNano() / 1000000
     go skynet(c, 0, 1000000, 10)
     result := <-c
     end := time.Now().UnixNano() / 1000000
     fmt.Printf("Result: %d in %d ms.\n", result, end - start)
 }
+


### PR DESCRIPTION
The current version only works on some platforms.  https://play.golang.org/p/pW14F8_IMz on the playground, it doesn't create the right result.  https://play.golang.org/p/0IeBdiS5C_ that code on the playground wraps around while on my local machine promotes on the `sum1 += 1` to give me `2147483648`, but on the `sum2 += 1000` it no-ops and leaves the value as `2147484647` as if there were no increment at all.

It doesn't seem to hugely alter the benchmark result, but it's worth having an implementation that doesn't have weird artifacts.

Old code:

```
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 783 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 506 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 524 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 652 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 729 ms.
```

New code:

```
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 789 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 625 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 755 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 791 ms.
bergstrom:go sean$ go run skynet.go 
Result: 499999500000 in 580 ms.
```

It might be slightly slower, but it's hard to say since my laptop is running lots of different things.
