### PR TITLE
Java version using fork/join

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ until reaching the root actor. (The answer should be 499999500000).
 - Erlang (HIPE): 3999 ms.
 - Go: 979 ms.
 - .NET Core: Async (8 threads) 650 ms / Sync (1 thread) 232 ms
+- Java: ?ms.
 
 ## Results (**i7-4770**, Win8.1): 
 
@@ -23,6 +24,7 @@ until reaching the root actor. (The answer should be 499999500000).
 - .NET Core: Async (8 threads) 290 ms / Sync (1 thread) 49 ms.
 - Node-bluebird (Promise) 285ms / 195ms (after warmup)
 - F# MailboxProcessor: 756ms (should be faster?..)
+- Java: ?ms
 
 ## How to run
 
@@ -84,3 +86,9 @@ Install [latest version of Crystal](http://crystal-lang.org/docs/installation/in
 Go to `crystal/`
 `crystal build skynet.cr --release`
 `./skynet`
+
+### Java
+
+Install a 1.8 JDK
+
+in `java/` run `javac Skynet.java` then `java Skynet`

--- a/README.md
+++ b/README.md
@@ -24,11 +24,8 @@ until reaching the root actor. (The answer should be 499999500000).
 - .NET Core: Async (8 threads) 290 ms / Sync (1 thread) 49 ms.
 - Node-bluebird (Promise) 285ms / 195ms (after warmup)
 - F# MailboxProcessor: 756ms (should be faster?..)
-<<<<<<< HEAD
-- Java: ?ms
-=======
 - .NET Full (TPL): 118 ms
->>>>>>> upstream/master
+- Java: ?ms
 
 ## How to run
 

--- a/java/Skynet.java
+++ b/java/Skynet.java
@@ -30,7 +30,9 @@ public class Skynet extends RecursiveAction {
 
             invokeAll(subtasks);
 
-            result = subtasks.stream().mapToLong(Skynet::result).sum();
+            for (Skynet task : subtasks) {
+                result += task.result();
+            }
         }
     }
 
@@ -38,16 +40,16 @@ public class Skynet extends RecursiveAction {
         return result;
     }
 
-    public static void main(String[] args) throws InterruptedException, ExecutionException {
+    public static void main(String[] args) {
         int limit = 1_000_000;
         ForkJoinPool pool = new ForkJoinPool();
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 25; i++) {
             long start = System.nanoTime();
             Skynet sky = new Skynet(0, limit, 10);
             pool.invoke(sky);
-            System.out.println("Result: " + sky.result());
             long end = System.nanoTime();
+            System.out.println("Result: " + sky.result());
             System.out.printf("Took: %.2fms%n", (end - start) / 1000000.0);
         }
     }

--- a/java/Skynet.java
+++ b/java/Skynet.java
@@ -1,0 +1,54 @@
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+
+public class Skynet extends RecursiveAction {
+    private long num;
+    private int size;
+    private int div;
+
+    private long result;
+
+    Skynet(long num, int size, int div) {
+        this.num = num;
+        this.size = size;
+        this.div = div;
+    }
+
+    @Override
+    public void compute() {
+        if (size == 1) {
+            result = num;
+        } else {
+            int newDiv = size / div;
+            List<Skynet> subtasks = new ArrayList<>(div);
+
+            for (long idx = 0; idx < div; idx++) {
+                long subNum = num + (idx * newDiv);
+                subtasks.add(new Skynet(subNum, newDiv, div));
+            }
+
+            invokeAll(subtasks);
+
+            result = subtasks.stream().mapToLong(Skynet::result).sum();
+        }
+    }
+
+    public long result() {
+        return result;
+    }
+
+    public static void main(String[] args) throws InterruptedException, ExecutionException {
+        int limit = 1_000_000;
+        ForkJoinPool pool = new ForkJoinPool();
+
+        for (int i = 0; i < 10; i++) {
+            long start = System.nanoTime();
+            Skynet sky = new Skynet(0, limit, 10);
+            pool.invoke(sky);
+            System.out.println("Result: " + sky.result());
+            long end = System.nanoTime();
+            System.out.printf("Took: %.2fms%n", (end - start) / 1000000.0);
+        }
+    }
+}


### PR DESCRIPTION
This is a Java implementation using the Fork/Join functionality of 1.7+ (this particular version requires 1.8 or more).

This runs the test ten times to see the effect of a cold vs. warm JVM.  On my machine it goes from 250ms to 50ms per run.  (By comparison the .NET Core version takes 500ms.)  If I run it 1000s of times it gets down to the 10ms to 15ms range.
