### PR TITLE
Concurrent Haskell Version using MVars

### DIFF
--- a/haskell-mvars/.gitignore
+++ b/haskell-mvars/.gitignore
@@ -1,0 +1,3 @@
+skynet
+*.hi
+*.o

--- a/haskell-mvars/Makefile
+++ b/haskell-mvars/Makefile
@@ -1,0 +1,5 @@
+skynet: skynet.hs
+	ghc -threaded -rtsopts -O3 -o skynet skynet.hs
+
+run: skynet
+	./skynet +RTS -N8 -H4G -RTS

--- a/haskell-mvars/skynet.hs
+++ b/haskell-mvars/skynet.hs
@@ -1,0 +1,27 @@
+import Control.Concurrent
+import Control.Concurrent.MVar
+import Control.Monad
+import Data.Time.Clock
+import Text.Printf
+
+spawn :: (a -> IO ()) -> a -> IO a
+spawn f x = forkIO (f x) >> return x
+
+skynet :: Int -> Int -> Int -> MVar Int -> IO ()
+skynet num 1    _    chan = putMVar chan num
+skynet num size part chan =
+    mapM job [0 .. pred part] >>= (fmap sum . mapM takeMVar) >>= putMVar chan
+  where
+    job i = newEmptyMVar >>= spawn (skynet (num + i * sd) sd part)
+      where
+        sd = size `div` part
+
+run :: IO ()
+run = do
+  start  <- getCurrentTime
+  result <- newEmptyMVar >>= spawn (skynet 0 1000000 10) >>= takeMVar
+  end    <- getCurrentTime
+  printf "Result: %d in %s\n" result (show $ diffUTCTime end start)
+
+main :: IO ()
+main = forM_ [1..10] (const run)


### PR DESCRIPTION
This adds a concurrent Haskell Version using MVars.

On my machine
- Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz
- Linux gghf 4.2.0-27-generic #32-Ubuntu SMP Fri Jan 22 04:49:08 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux

this gives me (it runs 10 times, run using `make run`) while watching Netflix O.o:

```
./skynet +RTS -N8 -H4G -RTS
Result: 499999500000 in 0.660476s
Result: 499999500000 in 0.486071s
Result: 499999500000 in 0.435496s
Result: 499999500000 in 0.381848s
Result: 499999500000 in 2.047777s
Result: 499999500000 in 0.371246s
Result: 499999500000 in 1.425728s
Result: 499999500000 in 0.372302s
Result: 499999500000 in 1.379577s
Result: 499999500000 in 0.400494s
```

which is better than the Chan or Async version on my machine.
