### PR TITLE
Make Haskell Use Control.Parallel

### DIFF
--- a/haskell/Skynet.hs
+++ b/haskell/Skynet.hs
@@ -4,7 +4,7 @@
 
 module Main (main) where
 
-import Control.Parallel.Strategies (parMap, rseq)
+import Control.Parallel.Strategies (evalList, rpar, using)
 import Control.Monad            (forM, replicateM_, void)
 import Data.Time.Clock          (getCurrentTime, diffUTCTime)
 
@@ -13,7 +13,7 @@ skynet levels children = sky levels 0
     where
         childnums = [0..children-1]
         sky 0   position = position
-        sky lvl position = sum $ parMap rseq (\cn -> sky (lvl-1) $ position*children + cn) childnums
+        sky lvl position = sum (map (\cn -> sky (lvl-1) $ position*children + cn) childnums `using` evalList rpar)
 
 doRun :: IO ()
 doRun = do


### PR DESCRIPTION
This needs the [`parallel`](https://hackage.haskell.org/package/parallel), but most Haskellers doing any kind of parallel work would likely have it. See [Parallel and Concurrent Haskell](http://chimera.labs.oreilly.com/books/1230000000929/ch03.html).

The `10` child threads are spawned by [`parMap`](https://hackage.haskell.org/package/parallel-3.2.1.0/docs/Control-Parallel-Strategies.html#v:parMap).

Here is the run I got:

```
$ ghc -O2 Skynet.hs -o skynet -threaded
[1 of 1] Compiling Main             ( Skynet.hs, Skynet.o )
Linking skynet ...


$ ./skynet +RTS -N2
Result: 499999500000 in 0.141922s
Result: 499999500000 in 0.063772s
Result: 499999500000 in 0.069988s
Result: 499999500000 in 0.046569s
Result: 499999500000 in 0.05068s
Result: 499999500000 in 0.045631s
Result: 499999500000 in 0.044842s
Result: 499999500000 in 0.044538s
Result: 499999500000 in 0.046612s
Result: 499999500000 in 0.044391s
```

Given that my computer was literally unable to run the old version, I would say this is faster. (It seems like the first run is always slower for some reason. I guess the parallel engine warming up for something.)
