### PR TITLE
Faster dotnetcore, add parallel, better timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Install latest version of .NET Core
 
 Go to `dnx/`  
 `dotnet restore` (first time)  
-`dotnet run`
+`dotnet run --configuration Release`
 
 ### Haskell
 

--- a/dnx/project.json
+++ b/dnx/project.json
@@ -4,10 +4,11 @@
         "emitEntryPoint": true
     },
 
-    "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23811",
-        "System.Threading.Tasks.Parallel": "4.0.1-rc2-23805"
-    },
+  "dependencies": {
+    "NETStandard.Library": "1.0.0-rc2-23811",
+    "System.Threading.Tasks.Extensions": "4.0.0-rc2-23812",
+    "System.Threading.Tasks.Parallel": "4.0.1-rc2-23805"
+  },
 
     "frameworks": {
         "dnxcore50": { }

--- a/dnx/project.json
+++ b/dnx/project.json
@@ -5,7 +5,8 @@
     },
 
     "dependencies": {
-        "NETStandard.Library": "1.0.0-rc2-23811"
+        "NETStandard.Library": "1.0.0-rc2-23811",
+        "System.Threading.Tasks.Parallel": "4.0.1-rc2-23805"
     },
 
     "frameworks": {


### PR DESCRIPTION
Added Parallel, Single threaded Async; multithreaded Async and ValueTask Async

If you use the Release config

```
dotnet run --configuration Release
```

or compile it in release mode...

```
dotnet compile --configuration Release -o bin
bin\dnx
```

The results are (Win10 on iMac Intel i5 @ 2.9GHz)

```
Arch 64 bit - Cores 4
499999500000
1 Thread - Sync: 5.756ms
499999500000
1 Thread - Async: 146.579ms
499999500000
1 Thread - ValueTask Async: 16.917ms
499999500000
Parallel Async: 86.191ms
499999500000
Parallel - ValueTask Async: 4.988ms
499999500000
Parallel Sync: 1.661ms
```

Debug mode matches the current results

```
Arch 64 bit - Cores 4
499999500000
1 Thread - Sync: 42.653ms
499999500000
1 Thread - Async: 186.333ms
499999500000
1 Thread - ValueTask Async: 64.792ms
499999500000
Parallel Async: 84.977ms
499999500000
Parallel - ValueTask Async: 19.903ms
499999500000
Parallel Sync: 13.490ms
```
