### PR TITLE
Scala Future monad

### DIFF
--- a/scala-future/Skynet.scala
+++ b/scala-future/Skynet.scala
@@ -1,0 +1,19 @@
+object Skynet extends App {
+  import concurrent._, duration._
+  import ExecutionContext.Implicits.global
+
+  def skynet(num: Int, size: Int, div: Int): Future[Long] =
+    if (size > 1) Future.sequence((0 until div) map (i =>
+      skynet(num + i * size / div, size / div, div))).map(_.sum)
+    else Future.successful(num)
+
+  def run(n: Int): Long = {
+    val start = System.nanoTime()
+    val x = Await.result(skynet(0, 1000000, 10), Duration.Inf)
+    val time = (System.nanoTime() - start) / 1000000
+    println(s"$n. Result: $x in $time ms.")
+    time
+  }
+
+  println(s"Best time ${(0 to 10) map (run) min} ms.")
+}

--- a/scala-future/build.sbt
+++ b/scala-future/build.sbt
@@ -1,0 +1,7 @@
+lazy val root = (project in file(".")).
+  settings(
+    name := "skynet",
+    scalaVersion := "2.11.7",
+    version := "0.1.0",
+    sbtVersion := "0.13.9"
+  )


### PR DESCRIPTION
Scala benchmark with Future monad in separate folder 'scala-future' 
(keeps original 'scala' folder with Akka implementation)

Results:

scala-future $ sbt run
[info] Running Skynet
0. Result: 499999500000 in 776 ms.
1. Result: 499999500000 in 320 ms.
2. Result: 499999500000 in 247 ms.
3. Result: 499999500000 in 233 ms.
4. Result: 499999500000 in 225 ms.
5. Result: 499999500000 in 210 ms.
6. Result: 499999500000 in 224 ms.
7. Result: 499999500000 in 209 ms.
8. Result: 499999500000 in 198 ms.
9. Result: 499999500000 in 211 ms.
10. Result: 499999500000 in 202 ms.
Best time 198 ms.
