### PR TITLE
Scala Future monad

### DIFF
--- a/scala-future/SkynetAsync.scala
+++ b/scala-future/SkynetAsync.scala
@@ -1,0 +1,22 @@
+package skynet
+
+object SkynetAsync extends App {
+  import concurrent._, duration._
+  import ExecutionContext.Implicits.global
+
+  def skynet(num: Int, size: Int, div: Int): Future[Long] =
+    if (size == 1) Future(num) else Future.sequence {
+      (0 until div) map (i =>
+        skynet(num + i * size / div, size / div, div))
+    } map (_.sum)
+
+  def run(n: Int): Long = {
+    val start = System.nanoTime()
+    val x = Await.result(skynet(0, 1000000, 10), Duration.Inf)
+    val time = (System.nanoTime() - start) / 1000000
+    println(s"$n. Result: $x in $time ms.")
+    time
+  }
+
+  println(s"Best time ${(0 to 10) map (run) min} ms.")
+}

--- a/scala-future/SkynetSync.scala
+++ b/scala-future/SkynetSync.scala
@@ -1,0 +1,19 @@
+package skynet
+
+object SkynetSync extends App {
+
+  def skynet(num: Int, size: Int, div: Int): Long =
+    if (size > 1) (0 until div).map(i =>
+      skynet(num + i * size / div, size / div, div)).sum
+    else num
+
+  def run(n: Int): Long = {
+    val start = System.nanoTime()
+    val x = skynet(0, 1000000, 10)
+    val time = (System.nanoTime() - start) / 1000000
+    println(s"$n. Result: $x in $time ms.")
+    time
+  }
+
+  println(s"Best time ${(0 to 10) map (run) min} ms.")
+}

--- a/scala-future/build.sbt
+++ b/scala-future/build.sbt
@@ -1,0 +1,7 @@
+lazy val root = (project in file(".")).
+  settings(
+    name := "skynet",
+    scalaVersion := "2.11.7",
+    version := "0.1.0",
+    sbtVersion := "0.13.9"
+  )


### PR DESCRIPTION
Fair async version without Future.successful:

[info] Running skynet.SkynetAsync
0. Result: 499999500000 in 647 ms.
1. Result: 499999500000 in 377 ms.
2. Result: 499999500000 in 372 ms.
3. Result: 499999500000 in 371 ms.
4. Result: 499999500000 in 342 ms.
5. Result: 499999500000 in 347 ms.
6. Result: 499999500000 in 367 ms.
7. Result: 499999500000 in 321 ms.
8. Result: 499999500000 in 308 ms.
9. Result: 499999500000 in 320 ms.
10. Result: 499999500000 in 338 ms.
Best time 308 ms.

Sync version for comparison:

[info] Running skynet.SkynetSync
0. Result: 499999500000 in 97 ms.
1. Result: 499999500000 in 60 ms.
2. Result: 499999500000 in 61 ms.
3. Result: 499999500000 in 67 ms.
4. Result: 499999500000 in 56 ms.
5. Result: 499999500000 in 64 ms.
6. Result: 499999500000 in 63 ms.
7. Result: 499999500000 in 62 ms.
8. Result: 499999500000 in 64 ms.
9. Result: 499999500000 in 63 ms.
10. Result: 499999500000 in 66 ms.
Best time 56 ms.
